### PR TITLE
Fix setup bug on pip 10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,13 @@ Flask-MailGun
 Flask extension to use the Mailgun email parsing service
 for sending and receving emails
 """
-from pip.req import parse_requirements
 from io import open
+
+try:
+    from pip.req import parse_requirements
+except ImportError:
+    from pip._internal.req import parse_requirements
+
 try:
     from setuptools import setup
 except ImportError:


### PR DESCRIPTION
pip.req is no longer in pip version 10. Have to user pip._internal.req for the setup to work. The fix is backward compatible with older versions of pip.